### PR TITLE
allow remove and edit of invoice in order to correct typos (costs do …

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -118,7 +118,7 @@ class NotesController < ApplicationController
       :contact_id,
       :title,
       :kind,
-      costs_attributes: [:price, :description, :amount, :vat]
+      costs_attributes: [:id, :price, :description, :amount, :vat]
     )
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -28,6 +28,7 @@ class Note < ActiveRecord::Base
 
   before_create :generate_and_set_note_number
   before_create :generate_and_set_pdf
+  before_update :generate_and_set_pdf
 
   validates :contact, presence: true
   validates :costs,   length: { minimum: 1 }

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -23,9 +23,6 @@ class Note < ActiveRecord::Base
 
   enum kind: {invoice: 0, credit: 1, income: 2, reminder: 3}
 
-  # Notes should be immutable and never changed.
-  #validate :force_immutable
-
   before_create :generate_and_set_note_number
   before_create :generate_and_set_pdf
   before_update :generate_and_set_pdf
@@ -84,12 +81,5 @@ class Note < ActiveRecord::Base
 
   def generate_and_set_pdf
     self.generated_pdf = generate_pdf
-  end
-
-  def force_immutable
-    return unless changed? && persisted?
-
-    errors.add(:base, :immutable)
-    reload
   end
 end

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -21,7 +21,7 @@
     = f.label :costs, class: 'label'
     table.table
       thead
-        th Datum
+        th Aantal
         th width='60%' Omschrijving
         th Bedrag
         th

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -35,9 +35,10 @@
               span.icon
                 = fa_icon 'plus'
               span Toevoegen
-
-
-  .actions
-    = f.submit "Factuur #{action}", class: 'button is-success'
+  .actions.field.is-grouped
+    p.control
+      = f.submit "Factuur #{action}", class: 'button is-primary'
+    p.control
+      = link_to 'Annuleer', notes_path, class: 'button is-default'
 script
   |  $(document).ready(function() { $("#e1").select2(); });

--- a/app/views/notes/_pdf.html.slim
+++ b/app/views/notes/_pdf.html.slim
@@ -96,9 +96,9 @@ section.sheet.padding-20mm
   .columns
     .column
       p
-        - if note.kind == :credit
-          strong Bovenvermeld bedrag zal op de rekening BE30 7330 0269 4711 gestort worden.
-        - elsif note.kind == :reminder
+        - if note.kind == "credit"
+          strong Bovenvermeld bedrag zal op de doorgegeven rekening gestort worden.
+        - elsif note.kind == "reminder"
           strong Gelieve bovenvermeld bedrag binnen de 8 dagen op rekeningnummer BE43 7310 4670 8101 met vermelding van het factuurnummer te storten. Indien wij het openstaande bedrag niet binnen 8 dagen ontvangen hebben dan zal deze vordering uit handen worden gegeven aan een incassobureau. Alle hieruit voortkomende kosten zullen voor uw rekening komen.
         - else
           strong Gelieve bovenvermeld bedrag binnen de 14 dagen na factuurdatum te betalen op rekeningnummer BE43 7310 4670 8101 met vermelding van het factuurnummer.
@@ -107,15 +107,15 @@ section.sheet.padding-20mm
 section.sheet.padding-10mm
   .content
     h2 ALGEMENE VOORWAARDEN
-    p De rechtsverhouding tussen 12urenloop Gent vzw, hierna genoemd 12UL met maatschappelijke zetel te Hoveniersberg 24, 9000 Gent, ingeschreven in de KBO onder het nummer 0692.988.190 en de contractspartij, wordt beheerst door onderhavige algemene voorwaarden, de facturen en de eventuele specifieke voorwaarden, opgenomen in de hoofdovereenkomst tussen partijen (hierna gezamenlijk aangeduid als "de Overeenkomst"). De Overeenkomst vernietigt en vervangt alle schriftelijke of mondelinge contracten, voorstellen en verbintenissen die betrekking hebben op hetzelfde voorwerp en die aan de datum van deze Overeenkomst zouden voorafgaan. De Overeenkomst heeft voorrang op de algemene en/of andere voorwaarden van de klant, zelfs indien deze bepalen dat zij als enige gelden. Afwijkingen ten opzichte van de Overeenkomst zijn slechts mogelijk na voorafgaande en schriftelijke toestemming van de 12UL. De 12UL behoudt zich het recht voor om de bepalingen van de Overeenkomst te wijzigen.
+    p De rechtsverhouding tussen 12urenloop Gent vzw, hierna genoemd 12ul met maatschappelijke zetel te Hoveniersberg 24, 9000 Gent, ingeschreven in de KBO onder het nummer 0692.988.190 en de contractspartij, wordt beheerst door onderhavige algemene voorwaarden, de facturen en de eventuele specifieke voorwaarden, opgenomen in de hoofdovereenkomst tussen partijen (hierna gezamenlijk aangeduid als "de Overeenkomst"). De Overeenkomst vernietigt en vervangt alle schriftelijke of mondelinge contracten, voorstellen en verbintenissen die betrekking hebben op hetzelfde voorwerp en die aan de datum van deze Overeenkomst zouden voorafgaan. De Overeenkomst heeft voorrang op de algemene en/of andere voorwaarden van de klant, zelfs indien deze bepalen dat zij als enige gelden. Afwijkingen ten opzichte van de Overeenkomst zijn slechts mogelijk na voorafgaande en schriftelijke toestemming van de 12ul. De 12ul behoudt zich het recht voor om de bepalingen van de Overeenkomst te wijzigen.
     ol
       li Onze algemene voorwaarden zijn van toepassing op alle overeenkomsten die worden afgesloten, behoudens uitdrukkelijk andersluidend beding en met uitsluiting van de algemene voorwaarden van de contractspartij.
       li Alle facturen dienen per overschrijving betaald te worden binnen veertien dagen na de factuurdatum en dit op de meegedeelde rekening en met vermelding van de meegedeelde gegevens op de factuur.
       li Al de prijzen vermeld op de factuur zijn exclusief 21% BTW, tenzij uitdrukkelijk anders vermeld wordt.
       li Bij een laattijdige betaling van de factuur zal een forfaitaire vergoeding van 15,00 EUR worden aangerekend per aanmaning die verstuurd wordt naar de ingebreke zijnde contractspartij.
       li Bovenop deze forfaitaire vergoeding zal bij een laattijdige betaling van de factuur, van rechtswege en zonder voorafgaande ingebrekestelling een interest verschuldigd zijn van 10% op het openstaand saldo van de factuur en dit per begonnen maand, waarbij elke begonnen maand een vervallen maand geacht wordt te zijn.
-      li Bij een laattijdige betaling van een factuur worden alle schuldvorderingen die 12UL bezit ten aanzien van de ingebreke zijnde contractspartij, onmiddellijk opeisbaar.
-      li Wanneer 12UL ten gevolge van overmacht niet in de mogelijkheid verkeert de overeenkomst uit te voeren, doordat het evenement niet georganiseerd kan worden, zullen de voorschotten niet terugbetaald kunnen worden. In ieder geval is de contractspartij gehouden zijn deel van de overeenkomst uit te voeren pro rata van het aantal dagen dat 12UL zijn deel van de overeenkomst heeft uitgevoerd.
-      li Indien door de contractspartij materiaal werd geleend aan 12UL zal geen enkele vergoeding aangerekend kunnen worden aan 12UL voor het verlies van materiaal, indien het geleende materiaal vroeger werd afgehaald dan contractueel overeengekomen.
+      li Bij een laattijdige betaling van een factuur worden alle schuldvorderingen die 12ul bezit ten aanzien van de ingebreke zijnde contractspartij, onmiddellijk opeisbaar.
+      li Wanneer 12ul ten gevolge van overmacht niet in de mogelijkheid verkeert de overeenkomst uit te voeren, doordat het evenement niet georganiseerd kan worden, zullen de voorschotten niet terugbetaald kunnen worden. In ieder geval is de contractspartij gehouden zijn deel van de overeenkomst uit te voeren pro rata van het aantal dagen dat 12ul zijn deel van de overeenkomst heeft uitgevoerd.
+      li Indien door de contractspartij materiaal werd geleend aan 12ul zal geen enkele vergoeding aangerekend kunnen worden aan 12ul voor het verlies van materiaal, indien het geleende materiaal vroeger werd afgehaald dan contractueel overeengekomen.
       li Al onze facturen worden geacht aanvaard te zijn indien zij binnen de 15 dagen na ontvangst niet betwist worden bij aangetekende brief.
       li In geval van betwisting zijn uitsluitend de rechtbanken van het gerechtelijk arrondissement Gent bevoegd.

--- a/app/views/notes/edit.html.slim
+++ b/app/views/notes/edit.html.slim
@@ -1,2 +1,2 @@
-h1.title Factuur updaten
-= render 'form', note: @note, action: 'updaten'
+h1.title Factuur aanpassen
+= render 'form', note: @note, action: 'aanpassen'

--- a/app/views/notes/index.html.slim
+++ b/app/views/notes/index.html.slim
@@ -32,7 +32,7 @@
                 p.control = link_to 'Verwijder', note, method: :delete, data: { confirm: 'Ben je zeker dat je deze factuur PERMANENT wil verwijderen?' }, class: 'button is-danger'
               - else
                 p.control = link_to 'Download', note_path(id: note.note_number, format: :pdf), target: :_blank, class: 'button is-primary'
-                p.control = link_to 'Edit', edit_note_path(note), class: 'button', disabled: true
+                p.control = link_to 'Edit', edit_note_path(note), class: 'button'
                 p.control = link_to 'Preview', note, class: 'button is-warning'
                 p.control = link_to 'Archiveer', archive_note_path(note), method: :post, data: { confirm: 'Ben je zeker dat je deze factuur wilt archiveren?' }, class: 'button is-danger'
                 p.control = link_to 'Verwijder', note, method: :delete, data: { confirm: 'Ben je zeker dat je deze factuur wilt verwijderen?' }, class: 'button is-danger'


### PR DESCRIPTION
Part of the changes were already present in master branch from 2 years ago. These new changes should complete this old sore of not being able to edit an invoice when a mistake is found just after creation.

Should also fix the rendering of pdf using full width of page!

Known issue: editing an invoice and removing a cost does not actually remove it (not necessary at the moment)

Last time, the build on the server did not work and there was no time at the moment to look into it. Hopefully more luck this time